### PR TITLE
improved webhook auth: verify github SHA1 signatures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -439,6 +439,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/glitch-dot-cool/droenbot#readme",
   "dependencies": {
     "axios": "^0.19.2",
+    "buffer-equal-constant-time": "^1.0.1",
     "colors": "^1.4.0",
     "discord.js": "^12.2.0",
     "express": "^4.17.1",

--- a/utils/middleware.js
+++ b/utils/middleware.js
@@ -1,13 +1,36 @@
+const crypto = require("crypto");
+const bufferEq = require("buffer-equal-constant-time");
 const { github_secret } = require("../config.json");
 
 const validate_github_webhook = (req, res, next) => {
-  const { ref: branch, secret } = req.body;
-  console.log(typeof secret, typeof github_secret, github_secret);
+  const { headers } = req;
+  const { ref: branch } = req.body;
+  const local_hash = hash_secret(github_secret, JSON.stringify(req.body));
+  const remote_hash = `sha1=${headers["x-hub-signature"]}`;
 
-  if (branch.includes("master") && secret === github_secret) {
+  if (branch.includes("master") && verify_signatures(local_hash, remote_hash)) {
     next();
   } else {
     res.status(401).json({ message: "Unauthorized" });
+  }
+};
+
+const hash_secret = (secret, payload) => {
+  return `sha1=${crypto
+    .createHmac("sha1", secret)
+    .update(payload)
+    .digest("hex")}`;
+};
+
+const verify_signatures = (buffer1, buffer2) => {
+  const a = Buffer.from(buffer1);
+  const b = Buffer.from(buffer2);
+
+  if (bufferEq(a, b)) {
+    return true;
+  } else {
+    // unauthorized
+    return false;
   }
 };
 


### PR DESCRIPTION
`validate_gihub_webhook()` now computes a local SHA1 signature and compares using `buffer-equal-constant-time` to the `x-hub-signature` sent from github in addition to checking that the webhook originates from the `master` branch (limiting update behavior to merged PRs and direct pushes to `master`).