### PR TITLE
remove forever global dependency in favor of diy node+bash restart 

### DIFF
--- a/api/webhook-router.js
+++ b/api/webhook-router.js
@@ -1,12 +1,22 @@
+const { exec } = require("child_process");
+const path = require("path");
 const router = require("express").Router();
-const { execSync } = require("child_process");
 const { validate_github_webhook } = require("../utils/middleware");
 
 router.post("/github", validate_github_webhook, async (req, res) => {
   try {
     res.status(200).end();
-    // update bot
-    execSync(`(git pull origin master && forever restart bot.js)`);
+    // run update script
+    exec(
+      `bash ${path.resolve(__dirname, "../scripts/update.sh")}`,
+      (err, stout, sterr) => {
+        if (!err) {
+          res
+            .status(500)
+            .json({ message: "Failed to update bot.", error: sterr });
+        }
+      }
+    );
   } catch (error) {
     res.status(500).json({
       message: "Failed to update and restart bot",

--- a/bot.js
+++ b/bot.js
@@ -1,3 +1,6 @@
+// set the process title so it can be killed with `npm run stop`
+process.title = "droenbot";
+
 const Discord = require("discord.js");
 const express = require("express");
 const colors = require("colors");

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "develop": "nodemon bot.js"
+    "develop": "nodemon bot.js",
+    "start": "node bot.js",
+    "stop": "pkill --signal SIGINT droenbot",
+    "restart": "npm run stop && npm run start"
   },
   "repository": {
     "type": "git",

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,2 @@
+git pull origin master
+npm run restart


### PR DESCRIPTION
turns out forever is kind of a pain if you're trying to use it for a non `root` user.
to simplify everything i'm just trying to leverage built-in node features by calling npm scripts inside a bash script using `exec`.
this should work for any user and doesn't require any dependencies 👍 