### PR TITLE
re-attempt forever restart strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "main": "index.js",
   "scripts": {
     "develop": "nodemon bot.js",
-    "start": "node bot.js",
-    "stop": "pkill --signal SIGINT droenbot",
-    "restart": "npm run stop && npm run start"
+    "start": "sudo -u root forever start bot.js",
+    "stop": "pkill --signal SIGINT droenbot"
   },
   "repository": {
     "type": "git",

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,2 +1,2 @@
 git pull origin master
-npm run restart
+sudo -u root forever restart bot.js


### PR DESCRIPTION
we're going to need some daemonized process to run the bot indefinitely. the issue with forever was that things get hairy when you run as a non-root user. so now the start/restart scripts will simply run as root which should restore `forever list`, which in turn enables `forever restart`.